### PR TITLE
Integration with sfinv_buttons

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,0 +1,1 @@
+sfinv_buttons?

--- a/init.lua
+++ b/init.lua
@@ -107,7 +107,18 @@ minetest.register_on_chat_message(function(name, message, pos)
 		
 end)
 
-
+if minetest.get_modpath("sfinv_buttons") then
+    sfinv_buttons.register_button("show_emoji_menu",
+    {
+        title = "Emoji Menu",
+        action = function(player)
+            local name = player:get_player_name()
+            minetest.show_formspec(name, "emoji_form", form)
+        end,
+        tooltip = "Show emoji menu",
+        image = "1_emoji.png",
+    })
+end
 
 
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,1 @@
+name = emoji


### PR DESCRIPTION
This PR adds integration with sfinv_buttons so there's some "graphical" way to summon the emoji menu
![Screenshot_20190920_023249](https://user-images.githubusercontent.com/12116711/65288619-2409cf00-db50-11e9-8c86-2d56ea6eab48.png)

